### PR TITLE
Add button to toggle (unlock) yubikey to indicator applet

### DIFF
--- a/YubiGuard/YubiGuard.py
+++ b/YubiGuard/YubiGuard.py
@@ -89,7 +89,7 @@ class PanelIndicator(object):
         self.indicator.set_menu(self.build_menu)
 
         self.pi_q = pi_q
-        self.on_q = on_q  # activate with: self.on_q.put(ON_SIGNAL)
+        self.on_q = on_q  
 
     def run_pi(self):
         # suppresses error: Couldn't connect to accessibility bus:
@@ -127,10 +127,7 @@ class PanelIndicator(object):
         return menu
 
     def unlock(self, *args):
-        context = zmq.Context()
-        zmq_socket = context.socket(zmq.PUSH)
-        zmq_socket.connect(URL)
-        zmq_socket.send(ON_SIGNAL)
+        self.on_q.put(ON_SIGNAL)
 
     def open_help(self, *arg):
         help_cmd = "xdg-open {HELP_URL} || " \
@@ -154,12 +151,15 @@ class PanelIndicator(object):
                 if state == ON_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(ON_ICON), "")
                     # activate unlock button
+                    self.indicator.gtk_widget_set_sensitive(self.item_unlock, true)                   
                 elif state == OFF_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(OFF_ICON), "")
                     # deactivate unlock button
+                    self.indicator.gtk_widget_set_sensitive(self.item_unlock, false)
                 elif state == NOKEY_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(NOKEY_ICON), "")
                     # deactivate unlock button
+                    self.indicator.gtk_widget_set_sensitive(self.item_unlock, false)
                 
             time.sleep(.1)
 

--- a/YubiGuard/YubiGuard.py
+++ b/YubiGuard/YubiGuard.py
@@ -112,6 +112,10 @@ class PanelIndicator(object):
     def build_menu(self):
         menu = Gtk.Menu()
 
+        item_unlock = Gtk.MenuItem('Unlock')
+        item_unlock.connect('activate', self.unlock)
+        menu.append(item_unlock)
+
         item_help = Gtk.MenuItem('Help')
         item_help.connect('activate', self.open_help)
         menu.append(item_help)
@@ -125,6 +129,10 @@ class PanelIndicator(object):
 
         menu.show_all()
         return menu
+
+    def unlock(self, *args):
+        # abspath is the own file name, we're executing ourselves with param -t (to unlock the yubikey)
+        subprocess.call(["/usr/bin/env", "python", abspath, "-t"])
 
     def open_help(self, *arg):
         help_cmd = "xdg-open {HELP_URL} || " \

--- a/YubiGuard/YubiGuard.py
+++ b/YubiGuard/YubiGuard.py
@@ -17,13 +17,12 @@ from multiprocessing.queues import Queue
 from threading import Thread
 
 import gi.repository
-gi.require_version('Gtk', '3.0')
-gi.require_version('AppIndicator3', '0.1')
-
 import zmq
 from gi.repository import AppIndicator3 as AppIndicator
 from gi.repository import Gtk
 
+gi.require_version('Gtk', '3.0')
+gi.require_version('AppIndicator3', '0.1')
 
 # change working dir to that of script:
 abspath = os.path.abspath(__file__)
@@ -86,11 +85,12 @@ class PanelIndicator(object):
         self.indicator = AppIndicator.Indicator.new(
             APPINDICATOR_ID, os.path.abspath(NOKEY_ICON),
             AppIndicator.IndicatorCategory.SYSTEM_SERVICES)
+
         self.indicator.set_status(AppIndicator.IndicatorStatus.ACTIVE)
         self.indicator.set_menu(self.build_menu)
 
         self.pi_q = pi_q
-        self.on_q = on_q  
+        self.on_q = on_q
 
     def run_pi(self):
         # suppresses error: Couldn't connect to accessibility bus:
@@ -113,6 +113,7 @@ class PanelIndicator(object):
         item_unlock.connect('activate', self.unlock)
         menu.append(item_unlock)
         self.item_unlock = item_unlock
+        self.item_unlock.set_sensitive(False)  # default state
 
         item_help = Gtk.MenuItem('Help')
         item_help.connect('activate', self.open_help)
@@ -159,10 +160,11 @@ class PanelIndicator(object):
                     # deactivate unlock button
                     self.item_unlock.set_sensitive(True)
                 elif state == NOKEY_SIGNAL:
-                    self.indicator.set_icon_full(os.path.abspath(NOKEY_ICON), "")
+                    self.indicator.set_icon_full(
+                        os.path.abspath(NOKEY_ICON), "")
                     # deactivate unlock button
-                    self.item_unlock.set_sensitive(True)
-                
+                    self.item_unlock.set_sensitive(False)
+
             time.sleep(.1)
 
 

--- a/YubiGuard/YubiGuard.py
+++ b/YubiGuard/YubiGuard.py
@@ -17,12 +17,13 @@ from multiprocessing.queues import Queue
 from threading import Thread
 
 import gi.repository
+gi.require_version('Gtk', '3.0')
+gi.require_version('AppIndicator3', '0.1')
+
 import zmq
 from gi.repository import AppIndicator3 as AppIndicator
 from gi.repository import Gtk
 
-gi.require_version('Gtk', '3.0')
-gi.require_version('AppIndicator3', '0.1')
 
 # change working dir to that of script:
 abspath = os.path.abspath(__file__)

--- a/YubiGuard/YubiGuard.py
+++ b/YubiGuard/YubiGuard.py
@@ -131,8 +131,6 @@ class PanelIndicator(object):
         return menu
 
     def unlock(self, *args):
-        # abspath is the own file name, we're executing ourselves with param -t (to unlock the yubikey)
-        print("Sending ON_SIGNAL.")
         context = zmq.Context()
         zmq_socket = context.socket(zmq.PUSH)
         zmq_socket.connect(URL)
@@ -157,10 +155,13 @@ class PanelIndicator(object):
 
                 if state == ON_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(ON_ICON), "")
+                    # activate unlock button
                 elif state == OFF_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(OFF_ICON), "")
+                    # deactivate unlock button
                 elif state == NOKEY_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(NOKEY_ICON), "")
+                    # deactivate unlock button
             time.sleep(.1)
 
 

--- a/YubiGuard/YubiGuard.py
+++ b/YubiGuard/YubiGuard.py
@@ -112,6 +112,7 @@ class PanelIndicator(object):
         item_unlock = Gtk.MenuItem('Unlock')
         item_unlock.connect('activate', self.unlock)
         menu.append(item_unlock)
+        self.item_unlock = item_unlock
 
         item_help = Gtk.MenuItem('Help')
         item_help.connect('activate', self.open_help)
@@ -152,15 +153,15 @@ class PanelIndicator(object):
                 if state == ON_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(ON_ICON), "")
                     # activate unlock button
-                    self.indicator.gtk_widget_set_sensitive(self.item_unlock, true)                   
+                    self.item_unlock.set_sensitive(False)
                 elif state == OFF_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(OFF_ICON), "")
                     # deactivate unlock button
-                    self.indicator.gtk_widget_set_sensitive(self.item_unlock, false)
+                    self.item_unlock.set_sensitive(True)
                 elif state == NOKEY_SIGNAL:
                     self.indicator.set_icon_full(os.path.abspath(NOKEY_ICON), "")
                     # deactivate unlock button
-                    self.indicator.gtk_widget_set_sensitive(self.item_unlock, false)
+                    self.item_unlock.set_sensitive(True)
                 
             time.sleep(.1)
 
@@ -233,7 +234,7 @@ class YubiGuard:
         zmq_lis_thr = Thread(target=zmq_lis.start_listener)
         zmq_lis_thr.setDaemon(True)
 
-        pi = PanelIndicator(self.pi_q)
+        pi = PanelIndicator(self.pi_q, self.on_q)
 
         # starting processes and catching exceptions:
         try:

--- a/YubiGuard/YubiGuard.py
+++ b/YubiGuard/YubiGuard.py
@@ -132,7 +132,11 @@ class PanelIndicator(object):
 
     def unlock(self, *args):
         # abspath is the own file name, we're executing ourselves with param -t (to unlock the yubikey)
-        subprocess.call(["/usr/bin/env", "python", abspath, "-t"])
+        print("Sending ON_SIGNAL.")
+        context = zmq.Context()
+        zmq_socket = context.socket(zmq.PUSH)
+        zmq_socket.connect(URL)
+        zmq_socket.send(ON_SIGNAL)
 
     def open_help(self, *arg):
         help_cmd = "xdg-open {HELP_URL} || " \


### PR DESCRIPTION
@bfelder What do you think?
One could rename "Toggle" to "Unlock" of course.

(This patch /might/ not cleanly apply, if you take my other pull request)