### PR TITLE
Update YubiGuard.py

### DIFF
--- a/YubiGuard/YubiGuard.py
+++ b/YubiGuard/YubiGuard.py
@@ -373,7 +373,7 @@ class YubiGuard:
             while stdout_queue.qsize() > 0:
                 stdout_queue.get()  # emptying queue
                 triggered = True
-                time.sleep(.01)
+                time.sleep(.04)
             if triggered:
                 print('YubiKey triggered. Now disabling.')
                 break


### PR DESCRIPTION
Yubikey is getting locked before it can finish typing full key (was only getting first 4 or 5 characters; the 'c' preamble). This change gives it enough time to complete.